### PR TITLE
Fix pipeline spelling error

### DIFF
--- a/workshop/content/java/buildpipe/done/_index.en.md
+++ b/workshop/content/java/buildpipe/done/_index.en.md
@@ -4,7 +4,7 @@ date = 2019-11-05T14:20:52-08:00
 weight = 35
 +++
 
-Let your pipline run every stage. After it finishes it will look all green like the following screenshot:
+Let your pipeline run every stage. After it finishes it will look all green like the following screenshot:
 
 ![VerifyPipelineRunning](/images/chapter4/screenshot-pipeline-verify-3.png)
 


### PR DESCRIPTION
pipline -> pipeline

Description of changes: Changed 'pipline' to 'pipeline'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.